### PR TITLE
Repair and Recycle Fixes

### DIFF
--- a/RTS-V-CUP.Altis/Zen_RTS_Functions/Zen_RTS_BuildStructure.sqf
+++ b/RTS-V-CUP.Altis/Zen_RTS_Functions/Zen_RTS_BuildStructure.sqf
@@ -93,7 +93,7 @@
 
         _slope = [_pos, 32] call Zen_FindTerrainSlope;
         _clutter = [_pos, 32] call Zen_GetAmbientClutterCount;
-        _objects = nearestObjects [_pos, [""], 30];
+        _objects = nearestObjects [_pos, [""], 10];
 
         {
             if ((BB_Volume(_x) < 1) || (BB_AreaXY(_x) < 0.5)) then {

--- a/RTS-V-CUP.Altis/Zen_RTS_Functions/Zen_RTS_GlobalFunctions.sqf
+++ b/RTS-V-CUP.Altis/Zen_RTS_Functions/Zen_RTS_GlobalFunctions.sqf
@@ -123,8 +123,28 @@ Zen_RTS_F_AddSpawnGridMarker = {
     (RTS_Building_Spawn_Grid_Markers select ([west, east] find _side)) pushBack _marker;
 };
 
+Zen_RTS_F_RemoveSpawnGridMarker = {
+    _marker = _this select 0;
+    _side = _this select 1;
+
+    0 = [(RTS_Building_Spawn_Grid_Markers select ([west, east] find _side)), _marker] call Zen_ArrayRemoveValue;
+};
+
 Zen_RTS_F_AddRecycleQueue = {
     _vehicle = _this select 0;
     (RTS_Recycle_Queue select (([west, east] find ([_vehicle] call Zen_GetSide)) max 0)) pushBack _vehicle;
 };
 
+Zen_RTS_F_RemoveRepairQueue = {
+    _building = _this select 0;
+    _side = _this select 1;
+
+    0 = [(RTS_Repair_Queue select ([west, east] find _side)), _building] call Zen_ArrayRemoveValue;
+};
+
+// Zen_RTS_F_RemoveRecycleQueue = {
+    // _vehicle = _this select 0;
+    // _side = _this select 1;
+
+    // 0 = [(RTS_Recycle_Queue select ([west, east] find _side)), _vehicle] call Zen_ArrayRemoveValue;
+// };

--- a/RTS-V-CUP.Altis/Zen_RTS_Functions/Zen_RTS_RecycleRepair.sqf
+++ b/RTS-V-CUP.Altis/Zen_RTS_Functions/Zen_RTS_RecycleRepair.sqf
@@ -80,9 +80,12 @@ if (_actionType == "Repair") then {
             _nearestObj setDamage 0; \
         }; \
         case "BuildingRuins": { \
+            _args = [_nearestObj, _nearestObj getVariable "Zen_RTS_StrategicBuildingSide"]; \
+            ZEN_FMW_MP_REServerOnly("Zen_RTS_F_RemoveRepairQueue", _args, call) \
             _type = _nearestObj getVariable "Zen_RTS_StrategicRuinsType"; \
             _side = _nearestObj getVariable "Zen_RTS_StrategicBuildingSide"; \
             _pos = getPosATL _nearestObj; \
+            sleep 1; \
             deleteVehicle _nearestObj; \
             _index = [_type, (RTS_Used_Building_Types select ([west, east] find _side))] call Zen_ValueFindInArray; \
             _level = RTS_Building_Type_Levels select ([west, east] find _side) select _index; \
@@ -101,6 +104,8 @@ if (_isAI) then {
         if (({alive _x} count (crew _nearestObj)) == 0) then {
             // playerMoney = playerMoney + _value;
             deleteVehicle _nearestObj;
+            // _args = [_nearestObj, side _nearestObj];
+            // ZEN_FMW_MP_REServerOnly("Zen_RTS_F_RemoveRecycleQueue", _args, call)
         };
     };
 } else {
@@ -131,9 +136,7 @@ if (_isAI) then {
             if (playerMoney > _value) then {
                 playerMoney = playerMoney - _value;
                 _unit groupChat ("You have paid: $" + (str round _value) + " to repair this object.");
-                
                 PROCESS_REPAIR
-
             } else {
                 _unit groupChat ("Insufficient funds, you need $" + (str round _value) + " to repair this object.");
             };
@@ -142,6 +145,8 @@ if (_isAI) then {
                 playerMoney = playerMoney + _value;
                 _unit groupChat ("You have received: $" + (str round _value) + " from recycling this object.");
                 deleteVehicle _nearestObj;
+                // _args = [_nearestObj, side _nearestObj];
+                // ZEN_FMW_MP_REServerOnly("Zen_RTS_F_RemoveRecycleQueue", _args, call)
             } else {
                 _unit groupChat ("You cannot recycle a vehicle with a crew in it!");
             };

--- a/RTS-V-CUP.Altis/init.sqf
+++ b/RTS-V-CUP.Altis/init.sqf
@@ -178,6 +178,8 @@ call compileFinal preprocessFileLineNumbers "Zen_RTS_SubTerritory\Zen_RTS_SubTer
                 0 = [(_buildingObjData select 1)] call Zen_RTS_StrategicBuildingDestroy; \
             }; \
             _building = _this select 0; \
+            _buildingSpawnGrid = _building getVariable "Zen_RTS_StrategicBuildingMarker"; \
+            0 = [(RTS_Repair_Queue select ([west, east] find S)), _building] call Zen_ArrayRemoveValue; \
             _pos = getPosATL _building; \
             sleep 5; \
             _objects = nearestObjects [_pos, ["All"], 10]; \
@@ -189,6 +191,9 @@ call compileFinal preprocessFileLineNumbers "Zen_RTS_SubTerritory\Zen_RTS_SubTer
             } forEach _objects; \
             if !(isNull _deadBuilding) then { \
                 diag_log ("ZEN_RTS_STRATEGIC_BUILDING_DESTROYED_EH found dead building" + str _deadBuilding); \
+                (RTS_Repair_Queue select ([west, east] find S)) pushBack _deadBuilding; \
+                _args = [_buildingSpawnGrid, S]; \
+                ZEN_FMW_MP_REAll("Zen_RTS_F_RemoveSpawnGridMarker", _args, call) \
                 _cost = call compile ([(_buildingTypeData select 5), "Cost: ", ","] call Zen_StringGetDelimitedPart); \
                 _deadBuilding setVariable ["Zen_RTS_StrategicType", "BuildingRuins", true]; \
                 _deadBuilding setVariable ["Zen_RTS_IsStrategicRepairable", true, true]; \

--- a/RTS-V-CUP.Sara/Zen_RTS_Functions/Zen_RTS_BuildStructure.sqf
+++ b/RTS-V-CUP.Sara/Zen_RTS_Functions/Zen_RTS_BuildStructure.sqf
@@ -93,7 +93,7 @@
 
         _slope = [_pos, 32] call Zen_FindTerrainSlope;
         _clutter = [_pos, 32] call Zen_GetAmbientClutterCount;
-        _objects = nearestObjects [_pos, [""], 30];
+        _objects = nearestObjects [_pos, [""], 10];
 
         {
             if ((BB_Volume(_x) < 1) || (BB_AreaXY(_x) < 0.5)) then {

--- a/RTS-V-CUP.Sara/Zen_RTS_Functions/Zen_RTS_GlobalFunctions.sqf
+++ b/RTS-V-CUP.Sara/Zen_RTS_Functions/Zen_RTS_GlobalFunctions.sqf
@@ -123,8 +123,28 @@ Zen_RTS_F_AddSpawnGridMarker = {
     (RTS_Building_Spawn_Grid_Markers select ([west, east] find _side)) pushBack _marker;
 };
 
+Zen_RTS_F_RemoveSpawnGridMarker = {
+    _marker = _this select 0;
+    _side = _this select 1;
+
+    0 = [(RTS_Building_Spawn_Grid_Markers select ([west, east] find _side)), _marker] call Zen_ArrayRemoveValue;
+};
+
 Zen_RTS_F_AddRecycleQueue = {
     _vehicle = _this select 0;
     (RTS_Recycle_Queue select (([west, east] find ([_vehicle] call Zen_GetSide)) max 0)) pushBack _vehicle;
 };
 
+Zen_RTS_F_RemoveRepairQueue = {
+    _building = _this select 0;
+    _side = _this select 1;
+
+    0 = [(RTS_Repair_Queue select ([west, east] find _side)), _building] call Zen_ArrayRemoveValue;
+};
+
+// Zen_RTS_F_RemoveRecycleQueue = {
+    // _vehicle = _this select 0;
+    // _side = _this select 1;
+
+    // 0 = [(RTS_Recycle_Queue select ([west, east] find _side)), _vehicle] call Zen_ArrayRemoveValue;
+// };

--- a/RTS-V-CUP.Sara/Zen_RTS_Functions/Zen_RTS_RecycleRepair.sqf
+++ b/RTS-V-CUP.Sara/Zen_RTS_Functions/Zen_RTS_RecycleRepair.sqf
@@ -80,9 +80,12 @@ if (_actionType == "Repair") then {
             _nearestObj setDamage 0; \
         }; \
         case "BuildingRuins": { \
+            _args = [_nearestObj, _nearestObj getVariable "Zen_RTS_StrategicBuildingSide"]; \
+            ZEN_FMW_MP_REServerOnly("Zen_RTS_F_RemoveRepairQueue", _args, call) \
             _type = _nearestObj getVariable "Zen_RTS_StrategicRuinsType"; \
             _side = _nearestObj getVariable "Zen_RTS_StrategicBuildingSide"; \
             _pos = getPosATL _nearestObj; \
+            sleep 1; \
             deleteVehicle _nearestObj; \
             _index = [_type, (RTS_Used_Building_Types select ([west, east] find _side))] call Zen_ValueFindInArray; \
             _level = RTS_Building_Type_Levels select ([west, east] find _side) select _index; \
@@ -101,6 +104,8 @@ if (_isAI) then {
         if (({alive _x} count (crew _nearestObj)) == 0) then {
             // playerMoney = playerMoney + _value;
             deleteVehicle _nearestObj;
+            // _args = [_nearestObj, side _nearestObj];
+            // ZEN_FMW_MP_REServerOnly("Zen_RTS_F_RemoveRecycleQueue", _args, call)
         };
     };
 } else {
@@ -131,9 +136,7 @@ if (_isAI) then {
             if (playerMoney > _value) then {
                 playerMoney = playerMoney - _value;
                 _unit groupChat ("You have paid: $" + (str round _value) + " to repair this object.");
-                
                 PROCESS_REPAIR
-
             } else {
                 _unit groupChat ("Insufficient funds, you need $" + (str round _value) + " to repair this object.");
             };
@@ -142,6 +145,8 @@ if (_isAI) then {
                 playerMoney = playerMoney + _value;
                 _unit groupChat ("You have received: $" + (str round _value) + " from recycling this object.");
                 deleteVehicle _nearestObj;
+                // _args = [_nearestObj, side _nearestObj];
+                // ZEN_FMW_MP_REServerOnly("Zen_RTS_F_RemoveRecycleQueue", _args, call)
             } else {
                 _unit groupChat ("You cannot recycle a vehicle with a crew in it!");
             };

--- a/RTS-V-CUP.Sara/init.sqf
+++ b/RTS-V-CUP.Sara/init.sqf
@@ -178,6 +178,8 @@ call compileFinal preprocessFileLineNumbers "Zen_RTS_SubTerritory\Zen_RTS_SubTer
                 0 = [(_buildingObjData select 1)] call Zen_RTS_StrategicBuildingDestroy; \
             }; \
             _building = _this select 0; \
+            _buildingSpawnGrid = _building getVariable "Zen_RTS_StrategicBuildingMarker"; \
+            0 = [(RTS_Repair_Queue select ([west, east] find S)), _building] call Zen_ArrayRemoveValue; \
             _pos = getPosATL _building; \
             sleep 5; \
             _objects = nearestObjects [_pos, ["All"], 10]; \
@@ -189,6 +191,9 @@ call compileFinal preprocessFileLineNumbers "Zen_RTS_SubTerritory\Zen_RTS_SubTer
             } forEach _objects; \
             if !(isNull _deadBuilding) then { \
                 diag_log ("ZEN_RTS_STRATEGIC_BUILDING_DESTROYED_EH found dead building" + str _deadBuilding); \
+                (RTS_Repair_Queue select ([west, east] find S)) pushBack _deadBuilding; \
+                _args = [_buildingSpawnGrid, S]; \
+                ZEN_FMW_MP_REAll("Zen_RTS_F_RemoveSpawnGridMarker", _args, call) \
                 _cost = call compile ([(_buildingTypeData select 5), "Cost: ", ","] call Zen_StringGetDelimitedPart); \
                 _deadBuilding setVariable ["Zen_RTS_StrategicType", "BuildingRuins", true]; \
                 _deadBuilding setVariable ["Zen_RTS_IsStrategicRepairable", true, true]; \

--- a/RTS-V-RHS.Altis/Zen_RTS_Functions/Zen_RTS_BuildStructure.sqf
+++ b/RTS-V-RHS.Altis/Zen_RTS_Functions/Zen_RTS_BuildStructure.sqf
@@ -93,7 +93,7 @@
 
         _slope = [_pos, 32] call Zen_FindTerrainSlope;
         _clutter = [_pos, 32] call Zen_GetAmbientClutterCount;
-        _objects = nearestObjects [_pos, [""], 30];
+        _objects = nearestObjects [_pos, [""], 10];
 
         {
             if ((BB_Volume(_x) < 1) || (BB_AreaXY(_x) < 0.5)) then {

--- a/RTS-V-RHS.Altis/Zen_RTS_Functions/Zen_RTS_GlobalFunctions.sqf
+++ b/RTS-V-RHS.Altis/Zen_RTS_Functions/Zen_RTS_GlobalFunctions.sqf
@@ -123,8 +123,28 @@ Zen_RTS_F_AddSpawnGridMarker = {
     (RTS_Building_Spawn_Grid_Markers select ([west, east] find _side)) pushBack _marker;
 };
 
+Zen_RTS_F_RemoveSpawnGridMarker = {
+    _marker = _this select 0;
+    _side = _this select 1;
+
+    0 = [(RTS_Building_Spawn_Grid_Markers select ([west, east] find _side)), _marker] call Zen_ArrayRemoveValue;
+};
+
 Zen_RTS_F_AddRecycleQueue = {
     _vehicle = _this select 0;
     (RTS_Recycle_Queue select (([west, east] find ([_vehicle] call Zen_GetSide)) max 0)) pushBack _vehicle;
 };
 
+Zen_RTS_F_RemoveRepairQueue = {
+    _building = _this select 0;
+    _side = _this select 1;
+
+    0 = [(RTS_Repair_Queue select ([west, east] find _side)), _building] call Zen_ArrayRemoveValue;
+};
+
+// Zen_RTS_F_RemoveRecycleQueue = {
+    // _vehicle = _this select 0;
+    // _side = _this select 1;
+
+    // 0 = [(RTS_Recycle_Queue select ([west, east] find _side)), _vehicle] call Zen_ArrayRemoveValue;
+// };

--- a/RTS-V-RHS.Altis/Zen_RTS_Functions/Zen_RTS_RecycleRepair.sqf
+++ b/RTS-V-RHS.Altis/Zen_RTS_Functions/Zen_RTS_RecycleRepair.sqf
@@ -80,9 +80,12 @@ if (_actionType == "Repair") then {
             _nearestObj setDamage 0; \
         }; \
         case "BuildingRuins": { \
+            _args = [_nearestObj, _nearestObj getVariable "Zen_RTS_StrategicBuildingSide"]; \
+            ZEN_FMW_MP_REServerOnly("Zen_RTS_F_RemoveRepairQueue", _args, call) \
             _type = _nearestObj getVariable "Zen_RTS_StrategicRuinsType"; \
             _side = _nearestObj getVariable "Zen_RTS_StrategicBuildingSide"; \
             _pos = getPosATL _nearestObj; \
+            sleep 1; \
             deleteVehicle _nearestObj; \
             _index = [_type, (RTS_Used_Building_Types select ([west, east] find _side))] call Zen_ValueFindInArray; \
             _level = RTS_Building_Type_Levels select ([west, east] find _side) select _index; \
@@ -101,6 +104,8 @@ if (_isAI) then {
         if (({alive _x} count (crew _nearestObj)) == 0) then {
             // playerMoney = playerMoney + _value;
             deleteVehicle _nearestObj;
+            // _args = [_nearestObj, side _nearestObj];
+            // ZEN_FMW_MP_REServerOnly("Zen_RTS_F_RemoveRecycleQueue", _args, call)
         };
     };
 } else {
@@ -131,9 +136,7 @@ if (_isAI) then {
             if (playerMoney > _value) then {
                 playerMoney = playerMoney - _value;
                 _unit groupChat ("You have paid: $" + (str round _value) + " to repair this object.");
-                
                 PROCESS_REPAIR
-
             } else {
                 _unit groupChat ("Insufficient funds, you need $" + (str round _value) + " to repair this object.");
             };
@@ -142,6 +145,8 @@ if (_isAI) then {
                 playerMoney = playerMoney + _value;
                 _unit groupChat ("You have received: $" + (str round _value) + " from recycling this object.");
                 deleteVehicle _nearestObj;
+                // _args = [_nearestObj, side _nearestObj];
+                // ZEN_FMW_MP_REServerOnly("Zen_RTS_F_RemoveRecycleQueue", _args, call)
             } else {
                 _unit groupChat ("You cannot recycle a vehicle with a crew in it!");
             };

--- a/RTS-V-RHS.Altis/init.sqf
+++ b/RTS-V-RHS.Altis/init.sqf
@@ -178,6 +178,8 @@ call compileFinal preprocessFileLineNumbers "Zen_RTS_SubTerritory\Zen_RTS_SubTer
                 0 = [(_buildingObjData select 1)] call Zen_RTS_StrategicBuildingDestroy; \
             }; \
             _building = _this select 0; \
+            _buildingSpawnGrid = _building getVariable "Zen_RTS_StrategicBuildingMarker"; \
+            0 = [(RTS_Repair_Queue select ([west, east] find S)), _building] call Zen_ArrayRemoveValue; \
             _pos = getPosATL _building; \
             sleep 5; \
             _objects = nearestObjects [_pos, ["All"], 10]; \
@@ -189,6 +191,9 @@ call compileFinal preprocessFileLineNumbers "Zen_RTS_SubTerritory\Zen_RTS_SubTer
             } forEach _objects; \
             if !(isNull _deadBuilding) then { \
                 diag_log ("ZEN_RTS_STRATEGIC_BUILDING_DESTROYED_EH found dead building" + str _deadBuilding); \
+                (RTS_Repair_Queue select ([west, east] find S)) pushBack _deadBuilding; \
+                _args = [_buildingSpawnGrid, S]; \
+                ZEN_FMW_MP_REAll("Zen_RTS_F_RemoveSpawnGridMarker", _args, call) \
                 _cost = call compile ([(_buildingTypeData select 5), "Cost: ", ","] call Zen_StringGetDelimitedPart); \
                 _deadBuilding setVariable ["Zen_RTS_StrategicType", "BuildingRuins", true]; \
                 _deadBuilding setVariable ["Zen_RTS_IsStrategicRepairable", true, true]; \


### PR DESCRIPTION
Fixed: Destroyed buildings are removed from the AI repair queue
Fixed: Destroyed buildings' ruins are added to the AI repair queue
Fixed: Buildings ruins are now an AI repairable type
Fixed: Buildings could not be built near destroyed buildings
